### PR TITLE
ZoomerBook

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -112,6 +112,35 @@
 	active = FALSE
 	UpdateButtonIcon()
 
+//Beggining of test
+/obj/item/book/granter/action/yeet
+	granted_action = /datum/action/innate/yeet
+	name = "Zoomer Book"
+	desc = "You feel compelled to throw this book.."
+	icon_state = "origamibook"	//Need a new Icon
+	actionname = "yeet"
+	oneuse = TRUE
+	remarks = list("Test Remark One", "Test Remark two")	//Need a remarks list
+
+/datum/action/innate/yeet
+	name = "Power Throwing"
+	desc = "Toggles your ability to throw with Zoomer force."
+	button_icon_state = "origami_off"	//Need a new Icon
+	check_flags = NONE
+
+/datum/action/innate/yeet/Activate()
+	to_chat(owner, "<span class='notice'>You will now throw with Zoomer force.</span>")
+	button_icon_state = "origami_on"	//Need a new Icon
+	active = TRUE
+	UpdateButtonIcon()
+
+/datum/action/innate/yeet/Deactivate()
+	to_chat(owner, "<span class='notice'>You will no longer throw with Zoomer force.</span>")
+	button_icon_state = "origami_off"	//Need a new Icon
+	active = FALSE
+	UpdateButtonIcon()
+//End of test
+
 ///SPELLS///
 
 /obj/item/book/granter/spell

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -545,3 +545,9 @@
 /obj/item/storage/box/syndie_kit/signaler/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/assembly/signaler(src)
+
+
+/obj/item/storage/box/syndie_kit/origami_bundle/PopulateContents()
+	new /obj/item/book/granter/action/yeet(src)
+	for(var/i in 1 to 5)
+		new /obj/item/paper(src)

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -6,3 +6,11 @@
 	cost = 8
 	restricted_roles = list("Curator")
 	limited_stock = 1 //for testing at least
+
+/datum/uplink_item/role_restricted/zoomer_book
+	name = "Zoomer Book"
+	desc = "A one use book that gives you the ability to learn the secret yeet technique mastered by tween of the early 3rd millenium. This will allow you to increase your throw damage, increasing with how loud you can scream it."
+	item = /obj/item/storage/box/syndie_kit/origami_bundle
+	cost = 7
+	restricted_roles = list("Assistant", "Bartender", "Botanist", "Chaplain", "Clown", "Cook", "Curator", "Janitor", "Mime")
+	limited_stock = 1 //for testing at least


### PR DESCRIPTION
Adds the Zoomer book which teaches you the Yeet power.

Still only grants origami plane power however.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ZoomerBook
7 TC - Assistant and Service only.
“A one use book that gives you the ability to learn the secret “yeet” technique mastered by tween of the early 3rd millenium.”

Grants the “yeet” spell

When the spell is selected it puts you in a state similar to the fireball spell, except on targeting it throws your in hand item. It will then exclaim “yeet” in the local area.
Damage multiplication for the item thrown depends on just how loud you can exclaim the phrase.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
.m dabs on your corpse.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added zoomer book
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
